### PR TITLE
Removed socket.setdefaulttimeout in favour of explicit timeout

### DIFF
--- a/src/googleanalytics/connection.py
+++ b/src/googleanalytics/connection.py
@@ -4,14 +4,12 @@ from googleanalytics.account import Account
 from xml.etree import ElementTree
 
 import re
-import socket
 import urllib
 import urllib2
 
 DEBUG = False
 PRETTYPRINT = True
-socket_timeout = 10
-socket.setdefaulttimeout(socket_timeout)
+TIMEOUT = 10
 
 class GAConnection:
     default_host = 'https://www.google.com'
@@ -105,7 +103,7 @@ class GAConnection:
             request = urllib2.Request(self.default_host + path, headers=headers)
 
         try:
-            response = urllib2.urlopen(request)
+            response = urllib2.urlopen(request, timeout=TIMEOUT)
         except urllib2.HTTPError, e:
             raise GoogleAnalyticsClientError(e)
         return response


### PR DESCRIPTION
Using socket.setdefaulttimeout interferes with some applications that rely on the default timeout (such as SocketServer in the Python stdlib). I've removed the call to socket.setdefaulttimeout and instead added an explicit timeout to urllib2.urlopen.
